### PR TITLE
Fix match error on cell_id

### DIFF
--- a/lib/kino_livereload.ex
+++ b/lib/kino_livereload.ex
@@ -100,7 +100,13 @@ defmodule KinoLiveReload do
 
   defmacro __using__(opts) do
     mods = Keyword.fetch!(opts, :watch)
-    "#cell:" <> cell_id = __CALLER__.file
+
+    "cell:" <> cell_id =
+      __CALLER__.file
+      |> Path.basename()
+      |> String.split("#")
+      |> List.last()
+
     mods = List.wrap(mods)
 
     quote do


### PR DESCRIPTION
This should fix issue #3.

`__CALLER__.file` includes the full livebook file path, which was causing the match to fail.
```
# Causes (MatchError) no match of right hand side value
"#cell:" <> cell_id = __CALLER__.file
```

Now the filename is extracted from the path and cell_id is matched against that.
```
"cell:" <> cell_id =
      __CALLER__.file
      |> Path.basename()
      |> String.split("#")
      |> List.last()
```

